### PR TITLE
Add services

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -19,9 +19,9 @@
     "docker": "yes",
     "__docker_namespace": "hypothesis",
     "__docker_network": "pyramid_app_cookiecutter_test_default",
-    "services": "no",
-    "db": "no",
+    "postgres": "yes",
     "frontend": "no",
+    "__postgres_port": "5438",
     "__frontend_typechecking": "no"
   }
 }

--- a/.cookiecutter/includes/.github/workflows/ci/services.yml
+++ b/.cookiecutter/includes/.github/workflows/ci/services.yml
@@ -1,0 +1,6 @@
+elasticsearch:
+  image: hypothesis/elasticsearch:latest
+  ports:
+  - 9201:9200
+  env:
+    discovery.type: single-node

--- a/.cookiecutter/includes/docker-compose/services.yml
+++ b/.cookiecutter/includes/docker-compose/services.yml
@@ -1,0 +1,11 @@
+elasticsearch:
+  image: hypothesis/elasticsearch:latest
+  ports:
+    - '127.0.0.1:9201:9200'
+  environment:
+    - discovery.type=single-node
+rabbit:
+  image: rabbitmq:3.6-management-alpine
+  ports:
+    - '127.0.0.1:5675:5672'
+    - '127.0.0.1:15675:15672'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,19 @@ jobs:
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.5-alpine
+        ports:
+        - 5438:5432
+      elasticsearch:
+        image: hypothesis/elasticsearch:latest
+        ports:
+        - 9201:9200
+        env:
+          discovery.type: single-node
+    env:
+      TEST_DATABASE_URL: postgresql://postgres@localhost:5438/pyramid_app_cookiecutter_test_test
     steps:
       - uses: actions/checkout@v3
       - name: Install Python
@@ -53,6 +66,8 @@ jobs:
           key: tests-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             tests-${{ runner.os }}-tox-
+      - name: Create test database
+        run: psql -U postgres -h localhost -p 5438 -c 'CREATE DATABASE pyramid_app_cookiecutter_test_test'
       - run: python -m pip install 'tox<4'
       - run: tox -e tests
       - name: Upload coverage file
@@ -84,6 +99,19 @@ jobs:
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.5-alpine
+        ports:
+        - 5438:5432
+      elasticsearch:
+        image: hypothesis/elasticsearch:latest
+        ports:
+        - 9201:9200
+        env:
+          discovery.type: single-node
+    env:
+      TEST_DATABASE_URL: postgresql://postgres@localhost:5438/pyramid_app_cookiecutter_test_test
     steps:
       - uses: actions/checkout@v3
       - name: Install Python
@@ -97,5 +125,7 @@ jobs:
           key: functests-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             functests-${{ runner.os }}-tox-
+      - name: Create test database
+        run: psql -U postgres -h localhost -p 5438 -c 'CREATE DATABASE pyramid_app_cookiecutter_test_test'
       - run: python -m pip install 'tox<4'
       - run: tox -e functests

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ help = help::; @echo $$$$(tput bold)$(strip $(1)):$$$$(tput sgr0) $(strip $(2))
 $(call help,make help,print this help message)
 
 .PHONY: services
+$(call help,make services,start the services that the app needs)
+services: args?=up -d
+services: python
+	@docker compose $(args)
 
 .PHONY: devdata
 
@@ -22,6 +26,11 @@ web: python
 $(call help,make shell,"launch a Python shell in this project's virtualenv")
 shell: python
 	@pyenv exec tox -qe dev --run-command 'pshell conf/development.ini'
+
+.PHONY: sql
+$(call help,make sql,"Connect to the dev database with a psql shell")
+sql: python
+	@docker compose exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
 $(call help,make lint,"lint the code and print any warnings")
@@ -114,6 +123,7 @@ $(call help,make docker-run,"run the app's docker image")
 docker-run:
 	@docker run \
 		--add-host host.docker.internal:host-gateway \
+		--net pyramid_app_cookiecutter_test_default \
 		--env-file .docker.env \
 		-p 9800:9800 \
 		hypothesis/pyramid-app-cookiecutter-test:$(DOCKER_TAG)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ First you'll need to install:
   The **Basic GitHub Checkout** method works best on Ubuntu.
   You _don't_ need to set up pyenv's shell integration ("shims"), you can
   [use pyenv without shims](https://github.com/pyenv/pyenv#using-pyenv-without-shims).
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+  On Ubuntu follow [Install on Ubuntu](https://docs.docker.com/desktop/install/ubuntu/).
+  On macOS follow [Install on Mac](https://docs.docker.com/desktop/install/mac-install/).
 
 Then to set up your development environment:
 
 ```terminal
 git clone https://github.com/hypothesis/pyramid-app-cookiecutter-test.git
 cd pyramid-app-cookiecutter-test
+make services
 make help
 ```
 

--- a/bin/create-db
+++ b/bin/create-db
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# Create the given database in Postgres, if it doesn't exist already.
+#
+# Usage:
+#
+#     create-db <DB_NAME>
+make services args="exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" > /dev/null 2>&1 || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:11.5-alpine
+    ports:
+      - "127.0.0.1:5438:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 1s
+  elasticsearch:
+    image: hypothesis/elasticsearch:latest
+    ports:
+      - '127.0.0.1:9201:9200'
+    environment:
+      - discovery.type=single-node
+  rabbit:
+    image: rabbitmq:3.6-management-alpine
+    ports:
+      - '127.0.0.1:5675:5672'
+      - '127.0.0.1:15675:15672'

--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,13 @@ deps =
     pip-tools
 depends =
     coverage: tests
+allowlist_externals =
+    tests,functests: sh
 commands_pre =
     pip-sync requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
 commands =
+    tests: sh bin/create-db pyramid_app_cookiecutter_test_test
+    functests: sh bin/create-db pyramid_app_cookiecutter_test_functests
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     format: black pyramid_app_cookiecutter_test tests bin
     format: isort --atomic pyramid_app_cookiecutter_test tests bin


### PR DESCRIPTION
Depends on https://github.com/hypothesis/cookiecutters/pull/97.

Use the cookiecutter's `"db"` option to add a Postgres service and also use the two `services.yml` includes to add Elasticsearch and RabbitMQ services to Docker Compose and CI.

Testing:

- [x] `make services` works
- [x] `make sql` works
- [x] `make sure` works
- [x] CI passes