### PR TITLE
Pin to tox<4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           key: format-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             format-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
           key: lint-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             lint-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
           key: tests-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             tests-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -80,7 +80,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -97,5 +97,5 @@ jobs:
           key: functests-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             functests-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e functests

--- a/bin/make_python
+++ b/bin/make_python
@@ -12,7 +12,7 @@ for python_version in 3.10.4; do
     bin_dir=$pyenv_root/versions/$python_version/bin
     if [ ! -f "$bin_dir"/tox ]; then
         pyenv install --skip-existing "$python_version"
-        "$bin_dir"/pip install --disable-pip-version-check tox
+        "$bin_dir"/pip install --disable-pip-version-check 'tox<4'
         pyenv rehash
     fi
 done

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = tests
 skipsdist = true
-minversion = 3.25.0
 requires =
+    tox>=3.25.0,<4
     tox-envfile
     tox-faster
     tox-run-command


### PR DESCRIPTION
Pin to tox<4 to avoid breakage caused by tox 4.0.0 backwards-incompatibilities.

See https://github.com/hypothesis/cookiecutter-pyapp-test/pull/6 for details.
