### PR TITLE
Add our standard deployment workflows

### DIFF
--- a/.cookiecutter/includes/.github/workflows/environments.json
+++ b/.cookiecutter/includes/.github/workflows/environments.json
@@ -1,0 +1,17 @@
+{
+  "qa": {
+    "github_environment_name": "QA",
+    "github_environment_url": "https://qa-test-pyramid-app.hypothes.is",
+    "aws_region": "us-west-1",
+    "elasticbeanstalk_application": "test-pyramid-app",
+    "elasticbeanstalk_environment": "qa"
+  },
+  "production": {
+    "needs": ["qa"],
+    "github_environment_name": "Production",
+    "github_environment_url": "https://test-pyramid-app.hypothes.is",
+    "aws_region": "us-west-1",
+    "elasticbeanstalk_application": "test-pyramid-app",
+    "elasticbeanstalk_environment": "prod"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     paths-ignore:
       - '.cookiecutter/*'
       - '.github/dependabot.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/redeploy.yml'
       - 'bin/logger'
       - 'bin/make_python'
       - 'bin/make_template'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: Deploy
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.cookiecutter/*'
+      - '.github/*'
+      - 'bin/create-db'
+      - 'bin/make_python'
+      - 'bin/make_template'
+      - 'conf/development.ini'
+      - 'conf/supervisord-dev.conf'
+      - 'docs/*'
+      - 'requirements/*'
+      - '!requirements/prod.txt'
+      - 'tests/*'
+      - '**/.gitignore'
+      - '.python-version'
+      - 'LICENSE'
+      - '*.md'
+      - 'docker-compose.yml'
+      - 'tox.ini'
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+  docker_hub:
+    name: Docker Hub
+    needs: [ci]
+    uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
+    with:
+      Application: ${{ github.event.repository.name }}
+    secrets: inherit
+  qa:
+    name: QA
+    needs: [docker_hub]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: deploy
+      github_environment_name: QA
+      github_environment_url: https://qa-test-pyramid-app.hypothes.is
+      aws_region: us-west-1
+      elasticbeanstalk_application: test-pyramid-app
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
+    secrets: inherit
+  production:
+    name: Production
+    needs: [docker_hub, qa]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: deploy
+      github_environment_name: Production
+      github_environment_url: https://test-pyramid-app.hypothes.is
+      aws_region: us-west-1
+      elasticbeanstalk_application: test-pyramid-app
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
+    secrets: inherit

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,0 +1,38 @@
+name: Redeploy
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    inputs:
+      qa:
+        type: boolean
+        description: Redeploy QA
+      production:
+        type: boolean
+        description: Redeploy Production
+jobs:
+  qa:
+    name: QA
+    if: inputs.qa
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: QA
+      github_environment_url: https://qa-test-pyramid-app.hypothes.is
+      aws_region: us-west-1
+      elasticbeanstalk_application: test-pyramid-app
+      elasticbeanstalk_environment: qa
+    secrets: inherit
+  production:
+    name: Production
+    if: inputs.production
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: Production
+      github_environment_url: https://test-pyramid-app.hypothes.is
+      aws_region: us-west-1
+      elasticbeanstalk_application: test-pyramid-app
+      elasticbeanstalk_environment: prod
+    secrets: inherit


### PR DESCRIPTION
This was done by creating the `environments.json` file that defines the environments for deploying to and then running `make template` which generates the `deploy.yml` and `redeploy.yml` files based on the `environments.json` file and [our cookiecutter template](https://github.com/hypothesis/cookiecutters) (and also changes part of `ci.yml` to account for the existence of the deployment workflows).
