### PR TITLE
Use `acks_late=True` in the test Celery task

### DIFF
--- a/test_pyramid_app/celery.py
+++ b/test_pyramid_app/celery.py
@@ -9,7 +9,7 @@ app = Celery("hello", broker=environ["BROKER_URL"])
 logger = get_task_logger(__name__)
 
 
-@app.task
+@app.task(acks_late=True)
 def work(seconds):  # pragma: no cover
     for second in reversed(range(seconds)):
         logger.info("Working %i", second + 1)


### PR DESCRIPTION
This is so that I can test what happens when a Celery task gets terminated mid-execution (e.g. by a deployment) before it has delivered its late acknowledgement to RabbitMQ. (The expectation is that after a `consumer_timeout` of 30 mins RabbitMQ will re-deliver the task to another worker.)
