### PR TITLE
Reorganise test-pyramid-app's Gunicorn config

### DIFF
--- a/.cookiecutter/includes/conf/supervisord-dev.conf.json
+++ b/.cookiecutter/includes/conf/supervisord-dev.conf.json
@@ -1,10 +1,10 @@
 {
   "programs": {
     "web": {
-      "command": "gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py"
+      "command": "newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py"
     },
     "worker": {
-      "command": "celery -A test_pyramid_app.celery:app worker --loglevel=INFO"
+      "command": "newreli-admin run-program celery -A test_pyramid_app.celery:app worker --loglevel=INFO"
     }
   }
 }

--- a/.cookiecutter/includes/conf/supervisord-dev.conf.json
+++ b/.cookiecutter/includes/conf/supervisord-dev.conf.json
@@ -1,7 +1,7 @@
 {
   "programs": {
     "web": {
-      "command": "gunicorn --bind :9800 --workers 1 --reload --timeout 0 --paste conf/development.ini"
+      "command": "gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py"
     },
     "worker": {
       "command": "celery -A test_pyramid_app.celery:app worker --loglevel=INFO"

--- a/.cookiecutter/includes/conf/supervisord.conf.json
+++ b/.cookiecutter/includes/conf/supervisord.conf.json
@@ -1,7 +1,7 @@
 {
   "programs": {
     "web": {
-      "command": "newrelic-admin run-program gunicorn --paste conf/production.ini --bind 0.0.0.0:9800"
+      "command": "newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py"
     },
     "worker": {
       "command": "newrelic-admin run-program celery -A test_pyramid_app.celery:app worker --loglevel INFO"

--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -1,0 +1,5 @@
+bind = "0.0.0.0:9800"
+reload = True
+reload_extra_files = "test_pyramid_app/templates"
+timeout = 0
+workers = 2

--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -2,4 +2,3 @@ bind = "0.0.0.0:9800"
 reload = True
 reload_extra_files = "test_pyramid_app/templates"
 timeout = 0
-workers = 2

--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -1,0 +1,2 @@
+bind = "0.0.0.0:9800"
+worker_tmp_dir = "/dev/shm"

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -3,7 +3,7 @@ nodaemon=true
 silent=true
 
 [program:web]
-command=gunicorn --bind :9800 --workers 1 --reload --timeout 0 --paste conf/development.ini
+command=gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal=KILL

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -3,14 +3,14 @@ nodaemon=true
 silent=true
 
 [program:web]
-command=gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py
+command=newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal=KILL
 stopasgroup=true
 
 [program:worker]
-command=celery -A test_pyramid_app.celery:app worker --loglevel=INFO
+command=newrelic-admin run-program celery -A test_pyramid_app.celery:app worker --loglevel=INFO
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal=KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:web]
-command=newrelic-admin run-program gunicorn --paste conf/production.ini --bind 0.0.0.0:9800
+command=newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py
 stdout_events_enabled=true
 stderr_events_enabled=true
 stdout_logfile=NONE


### PR DESCRIPTION
This reorganise's test-pyramid-app's Gunicorn config files following the
same pattern as was recently done in h:

hypothesis/h#8407

I'm applying this simpler and more explicit Gunicorn config approach to
all our apps consistently. For motivation see:

https://docs.google.com/document/d/13AnUPtu9AO3PfRm-fhH7_3RZzyLGSFd4uPv36dIeynA

Benefits:

* Gunicorn config files are explicitly mentioned in the `gunicorn`
  commands in the `supervisord[-dev].conf` files. This makes things less
  confusing/surprising, less likely that a Gunicorn config file will be
  missed (compared to Gunicorn's default behavior if you run it without
  a `--config` argument: it reads any `gunicorn.conf.py` file in the
  current working directory).

* The Gunicorn config files are in the `conf/` directory with the other
  config files. Again: makes it less likely that a config file will go
  unnoticed.

* Separate production and development Gunicorn config files. This is
  consistent with our separate production and development Pyramid config
  files, and is probably a good idea to prevent development settings
  accidentally getting applied in production. (Gunicorn's default
  behavior of reading a root `gunicorn.conf.py` file would mean that
  file gets read in both dev and production).
