### PR TITLE
Enable Sentry's "releases" feature

### DIFF
--- a/test_pyramid_app/app.py
+++ b/test_pyramid_app/app.py
@@ -9,6 +9,7 @@ from pyramid.session import SignedCookieSessionFactory
 from pyramid.view import forbidden_view_config, view_config, view_defaults
 from sentry_sdk import capture_message
 
+from test_pyramid_app._version import get_version
 from test_pyramid_app.celery import work
 
 
@@ -53,6 +54,18 @@ def create_app(_=None, **settings):
         config.include("pyramid_googleauth")
 
         config.include("pyramid_jinja2")
+
+        # Enable Sentry's "Releases" feature, see:
+        # https://docs.sentry.io/platforms/python/configuration/options/#release
+        #
+        # h_pyramid_sentry passes any h_pyramid_sentry.init.* Pyramid settings
+        # through to sentry_sdk.init(), see:
+        # https://github.com/hypothesis/h-pyramid-sentry?tab=readme-ov-file#settings
+        #
+        # For the full list of options that sentry_sdk.init() supports see:
+        # https://docs.sentry.io/platforms/python/configuration/options/
+        settings["h_pyramid_sentry.init.release"] = get_version()
+
         config.include("h_pyramid_sentry")
 
         config.scan()


### PR DESCRIPTION
The releases feature is useful in itself, and this should also stop the
"discarded session update because of missing release" messages that
`sentry_sdk` is logging all the time.
